### PR TITLE
Match objects with a hash-style matching

### DIFF
--- a/test/test_pattern-match.rb
+++ b/test/test_pattern-match.rb
@@ -342,6 +342,20 @@ class TestPatternMatch < Test::Unit::TestCase
     }
   end
 
+  def test_deconstructor_class_attributes_with_hash
+    person_class = Struct.new(:name, :age) do
+      include PatternMatch::ObjectHashMatcher
+    end
+    
+    match(person_class.new("Mary", 50)) {
+      with(person_class.(:name => name, :age => age)) {
+        assert_equal("Mary", name)
+        assert_equal(50, age)
+      }
+      with(_) { flunk }
+    }
+  end
+
   def test_deconstructor_class_complex
     match(Complex(0, 1)) {
       with(Complex.(a, b)) {


### PR DESCRIPTION
The module already supports matching structs using the same arguments of the constructor. I propose a more general object matching using the syntax already used to match hashes, but instead of keys we would match attributes.

With the patch applied, this snippet works:

```
require 'pattern-match'

class Person < Struct.new(:name, :age)
  include PatternMatch::ObjectHashMatcher
end

match Person.new("John", 21) do
  with Person.(:name, :age => 21) do
    puts("name: #{name}")
  end
end
```

I am not sure what's the best way to implement this and how to make it compatible with what we have in Struct. Any suggestions to improve the patch most welcome.

(BTW, great library, I've been looking for a pattern-matching library in Ruby for a long time and yours is incredibly versatile).
